### PR TITLE
set defaults via ~/.python-translate.cfg

### DIFF
--- a/translate
+++ b/translate
@@ -12,6 +12,13 @@
 # beer too.
 # ----------------------------------------------------------------------------
 from translate import main
+import ConfigParser, os
 
 if __name__ == "__main__":
-    main()
+    parser = ConfigParser.SafeConfigParser({'from_lang': 'auto', 'to_lang': 'zh'})
+    fn = os.path.expanduser('~/.python-translate.cfg')
+    if not parser.read(fn):
+        with open(fn, 'wb') as configfile:
+            parser.write(configfile) 
+    d = 'DEFAULT'
+    main({'f': parser.get(d,'from_lang'), 't':parser.get(d,'to_lang') })

--- a/translate.py
+++ b/translate.py
@@ -50,17 +50,21 @@ class Translator:
         r = request.urlopen(req)
         return r.read().decode('utf-8')
 
-def main():
+def main(defvals=None):
     import argparse
     import sys
     import locale
+
+    if defvals is None:
+       defvals = {'f':'auto', 't':'zh'} 
+
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('texts', metavar='text', nargs='+',
                    help='a string to translate(use "" when it\'s a sentence)')
-    parser.add_argument('-t', '--to', dest='to_lang', type=str, default='zh',
-                   help='To language (e.g. zh, zh-TW, en, ja, ko). Default is zh.')
-    parser.add_argument('-f', '--from', dest='from_lang', type=str, default='auto',
-                   help='From language (e.g. zh, zh-TW, en, ja, ko). Default is auto.')
+    parser.add_argument('-t', '--to', dest='to_lang', type=str, default=defvals['t'],
+                   help='To language (e.g. zh, zh-TW, en, ja, ko). Default is '+defvals['t']+'.')
+    parser.add_argument('-f', '--from', dest='from_lang', type=str, default=defvals['f'],
+                   help='From language (e.g. zh, zh-TW, en, ja, ko). Default is '+defvals['f']+'.')
     args = parser.parse_args()
     translator= Translator(from_lang=args.from_lang, to_lang=args.to_lang)
     for text in args.texts:


### PR DESCRIPTION
I'm using it via command line, and my default language is not zh.
This change will create ~/.python-translate.cfg if not exist, and will allow to set user-local change of default to/from languages.