### PR TITLE
Add makefile commands

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changelog
 ---------
 
+3.4.1
+-----
+
+* Makefile: Add a make release command
+* Add twine to dev requirements.
+
 3.4.0
 -----
 

--- a/Makefile
+++ b/Makefile
@@ -17,16 +17,26 @@ clean-build:
 lint:
 	pre-commit run -av
 
-dev:
+pip-install:
 	pip install -r requirements-dev.txt
 
-test: dev
+pip-upgrade:
+	pip install --upgrade -r requirements-dev.txt
+
+cov:
+	coverage report -m
+
+cov-report:
+	py.test -vv --cov-report=html tests
+
+test: pip-install
 	py.test -vv -s
 
 build: test
 	python setup.py sdist
 	python setup.py bdist_wheel
 
-
-pip-install:
-	pip install --upgrade -r requirements-dev.txt
+release: build
+	git tag `python setup.py -q version`
+	git push origin `python setup.py -q version`
+	twine upload dist/*

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,4 +6,5 @@ pre-commit
 pytest
 pytest-cov
 tox
+twine
 vcrpy

--- a/translate/main.py
+++ b/translate/main.py
@@ -60,7 +60,7 @@ def print_version(ctx, param, value):
 @click.option(
     'provider', '--provider', '-p',
     default=DEFAULT_PROVIDER,
-    help="The providers name you wish to use. The default value is '{}'".format(DEFAULT_PROVIDER)
+    help="Set the provider you want to use. The default value is '{}'".format(DEFAULT_PROVIDER)
 )
 @click.option(
     'secret_access_key', '--secret_access_key',
@@ -74,13 +74,13 @@ def main(from_lang, to_lang, provider, secret_access_key, text):
 
     \b
     Example:
-
+    \b
     \t $ translate-cli -t zh the book is on the table
     \t 碗是在桌子上。
 
     \b
     Available languages:
-
+    \b
     \t https://en.wikipedia.org/wiki/ISO_639-1
     \t Examples: (e.g. en, ja, ko, pt, zh, zh-TW, ...)
     """


### PR DESCRIPTION
PR with a release command to create the tag and release when uploading a new release to PyPi The command use Twine (https://pypi.python.org/pypi/twine) cause is more safe to use than `setup.py upload`

When you want to generate a new release you do like this:

- Make release (This command use the build command but in the end will as your credential to upload your files.)

```shell
$ make release
```
