### PR TITLE
[Issue #38] Use config file to get the provider and the secret_access_key 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,42 +16,80 @@ translate实现的命令行工具（translate），也可以当做Python模块�
 Installation
 ------------
 
-::
+.. code-block:: bash
 
-   pip install translate
+   $ pip install translate
 
 Or, you can download the source and
 
-::
+.. code-block:: bash
 
-   python setup.py install
+   $ python setup.py install
 
 Add sudo in the beginning if you met problem.
 
-Command-Line Usage
-------------------
+Usage
+-----
 
 In your command-line:
 
-::
+.. code-block:: bash
 
-   translate-cli "This is a pen."
+   $ translate-cli "This is a pen."
+
+   Translation: O livro esta em cima da mesa
+   -------------------------
+   Translated by: MyMemory
 
 Or
 
-::
+.. code-block:: bash
 
-   translate-cli -f zh -t ja
+   $ translate-cli -f zh -t ja -o
    我是谁？
+
+Options
+~~~~~~~
+
+.. code-block:: bash
+
+    $ translate-cli --help
+    Usage: __main__.py [OPTIONS] TEXT...
+
+      Python command line tool to make on line translations
+
+      Example:
+
+           $ translate-cli -t zh the book is on the table
+           碗是在桌子上。
+
+      Available languages:
+
+           https://en.wikipedia.org/wiki/ISO_639-1
+           Examples: (e.g. en, ja, ko, pt, zh, zh-TW, ...)
+
+    Options:
+      --version                 Show the version and exit.
+      --generate-config-file    Generated the config file using a Wizard and exit.
+      -f, --from TEXT           Sets the language of the text being translated.
+                                The default value is 'autodetect'.
+      -t, --to TEXT             Sets the language you want to translate.
+      -p, --provider TEXT       Set the provider you want to use. The default
+                                value is 'mymemory'.
+      --secret_access_key TEXT  Set the secret access key used to get provider
+                                oAuth token.
+      -o, --output_only         Set to display the translation only.
+      --help                    Show this message and exit.
 
 Use As A Python Module
 ----------------------
 
-::
+.. code-block:: python
 
-   from translate import Translator
-   translator= Translator(to_lang="zh")
-   translation = translator.translate("This is a pen.")
+   In [1]: from translate import Translator
+   In [2]: translator= Translator(to_lang="zh")
+   In [3]: translation = translator.translate("This is a pen.")
+   Out [3]: 这是一支笔
 
 The result is in translation, and it’s usually a unicode string.
 
@@ -60,7 +98,7 @@ Change Default Languages
 
 In ~/.python-translate.cfg:
 
-::
+.. code-block:: bash
 
    [DEFAULT]
    from_lang = autodetect
@@ -75,15 +113,14 @@ The country code, as far as I know, is following https://en.wikipedia.org/wiki/I
 Use a different translation provider
 ------------------------------------
 
-::
+.. code-block:: python
 
-    from translate import Translator
-    to_lang = 'en'
-    secret = '<your secret from Microsoft>'
-    translator = Translator(provider='microsoft', to_lang=to_lang, secret_access_key=secret)
-    translator.translate('the book is on the table')
-
-    > '碗是在桌子上。'
+    In [1]: from translate import Translator
+    In [2]: to_lang = 'zh'
+    In [3]: secret = '<your secret from Microsoft>'
+    In [4]: translator = Translator(provider='microsoft', to_lang=to_lang, secret_access_key=secret)
+    In [5]: translator.translate('the book is on the table')
+    Out [5]: '碗是在桌子上。'
 
 Contribution
 ------------

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,4 @@
+=======================
 google-translate-python
 =======================
 
@@ -7,7 +8,7 @@ usage. Please let me know if there's any other better free translation API.
 
 The default from language is English (en).
 The default to language is Simplified Chinese (zh). Of course, you can specify it
-in the parameter or commandline.
+in the parameter or command line.
 
 利用google
 translate实现的命令行工具（translate），也可以当做Python模块用在你的代码中。
@@ -40,7 +41,8 @@ Or
 
 ::
 
-   translate-cli -f zh -t ja 我是谁？
+   translate-cli -f zh -t ja
+   我是谁？
 
 Use As A Python Module
 ----------------------
@@ -54,35 +56,37 @@ Use As A Python Module
 The result is in translation, and it’s usually a unicode string.
 
 Change Default Languages
-----------------------
+------------------------
 
 In ~/.python-translate.cfg:
 
 ::
 
    [DEFAULT]
-   from_lang = auto
-   to_lang = 'de'
+   from_lang = autodetect
+   to_lang = de
+   provider = mymemory
+   secret_access_key =
 
 The cfg is not for using as a Python module.
 The country code, as far as I know, is following https://en.wikipedia.org/wiki/ISO_639-1.
 
 
 Use a different translation provider
------------------------------------
+------------------------------------
 
 ::
+
     from translate import Translator
-    from translate.providers import MicrosoftProvider
-    from_lang = 'en'
+    to_lang = 'en'
     secret = '<your secret from Microsoft>'
-    translator = Translator(provider=MicrosoftProvider, from_lang=from_lang, to_lang=to_lang, secret_access_key=secret)
+    translator = Translator(provider='microsoft', to_lang=to_lang, secret_access_key=secret)
     translator.translate('the book is on the table')
 
     > '碗是在桌子上。'
 
 Contribution
------------------------
+------------
 
 Please send pull requests, very much appriciated.
 

--- a/sample-python-translate.cfg
+++ b/sample-python-translate.cfg
@@ -1,4 +1,5 @@
 [DEFAULT]
 to_lang = zh
 from_lang = autodetect
-
+provider = mymemory
+secret_access_key =

--- a/tests/fixtures/cassettes/test_main_to_language_output_only.yaml
+++ b/tests/fixtures/cassettes/test_main_to_language_output_only.yaml
@@ -1,0 +1,44 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: ['Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebit/535.19(KHTML,
+          like Gecko) Chrome/18.0.1025.168 Safari/535.19']
+    method: GET
+    uri: http://api.mymemory.translated.net/get?q=love&langpair=autodetect%7Czh-TW
+  response:
+    body: {string: "\r\n{\"responseData\":{\"translatedText\":\"\\u7231\",\"match\"\
+        :1,\"detectedLanguage\":\"English\"},\"quotaFinished\":false,\"responseDetails\"\
+        :\"\",\"responseStatus\":200,\"responderId\":\"236\",\"matches\":[{\"id\"\
+        :\"436719800\",\"segment\":\"love\",\"translation\":\"\\u7231\",\"quality\"\
+        :\"74\",\"reference\":null,\"usage-count\":25,\"subject\":\"All\",\"created-by\"\
+        :\"MateCat\",\"last-updated-by\":\"MateCat\",\"create-date\":\"2016-06-14\
+        \ 15:28:03\",\"last-update-date\":\"2016-06-14 15:28:03\",\"match\":1},{\"\
+        id\":\"431321273\",\"segment\":\"love\",\"translation\":\"w ho liau\",\"quality\"\
+        :\"74\",\"reference\":null,\"usage-count\":1,\"subject\":\"General\",\"created-by\"\
+        :\"MateCat\",\"last-updated-by\":\"\",\"create-date\":\"2014-07-26 17:17:27\"\
+        ,\"last-update-date\":\"2014-08-12 06:47:10\",\"match\":0.99},{\"id\":\"464574969\"\
+        ,\"segment\":\"Love\",\"translation\":\"\\u559c\\u6b22\",\"quality\":\"74\"\
+        ,\"reference\":null,\"usage-count\":9,\"subject\":\"All\",\"created-by\":\"\
+        MateCat\",\"last-updated-by\":\"MateCat\",\"create-date\":\"2017-11-25 11:44:15\"\
+        ,\"last-update-date\":\"2017-11-25 11:44:15\",\"match\":0.98}]}"}
+    headers:
+      Access-Control-Allow-Origin: ['*']
+      Cache-Control: ['no-cache, no-store, max-age=0, must-revalidate']
+      Connection: [close]
+      Content-Length: ['977']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Tue, 28 Nov 2017 18:42:03 GMT']
+      Expires: ['Fri, 01 Jan 1990 00:00:00 GMT']
+      Pragma: [no-cache]
+      Server: [Apache/2.4.10 (Debian)]
+      X-Backend-Content-Length: ['10']
+      X-Embedded-Status: ['200']
+      X-Frame-Options: [SAMEORIGIN]
+      X-Powered-By: [PHP/5.6.30-0+deb8u1]
+      X-XSS-Protection: ['0']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -31,6 +31,12 @@ def test_main_to_language(cli_runner):
 
 
 @vcr.use_cassette
+def test_main_to_language_output_only(cli_runner):
+    result = cli_runner.invoke(main, ['-t', 'zh-TW', '-o', 'love'])
+    assert '爱\n' == result.output
+
+
+@vcr.use_cassette
 def test_main_from_language(cli_runner):
     result = cli_runner.invoke(main, ['--from', 'ja', '--to', 'zh', '美'])
     assert response_template.format('美') == result.output

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -21,7 +21,7 @@ response_template = (
 def test_main_language_to_translate_required(cli_runner):
     result = cli_runner.invoke(main, ['hello', 'world'], input='zh')
     response = response_template.format('你好，世界')
-    assert 'Translate to [zh]: zh\n{}'.format(response) == result.output
+    assert 'Translate to []: zh\n{}'.format(response) == result.output
 
 
 @vcr.use_cassette

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -10,23 +10,30 @@ from translate.main import main
 
 from .vcr_conf import vcr
 
+response_template = (
+    '\nTranslation: {}\n'
+    '-------------------------\n'
+    'Translated by: MyMemory\n'
+)
+
 
 @vcr.use_cassette
 def test_main_language_to_translate_required(cli_runner):
     result = cli_runner.invoke(main, ['hello', 'world'], input='zh')
-    assert 'Translate to []: zh\n你好，世界\n' == result.output
+    response = response_template.format('你好，世界')
+    assert 'Translate to [zh]: zh\n{}'.format(response) == result.output
 
 
 @vcr.use_cassette
 def test_main_to_language(cli_runner):
     result = cli_runner.invoke(main, ['-t', 'zh-TW', 'love'])
-    assert '爱\n' == result.output
+    assert response_template.format('爱') == result.output
 
 
 @vcr.use_cassette
 def test_main_from_language(cli_runner):
     result = cli_runner.invoke(main, ['--from', 'ja', '--to', 'zh', '美'])
-    assert '美\n' == result.output
+    assert response_template.format('美') == result.output
 
 
 @mock.patch('translate.main.__version__', '0.0.0')

--- a/translate/main.py
+++ b/translate/main.py
@@ -126,8 +126,15 @@ def config_file(ctx, from_lang, to_lang, provider, secret_access_key):
     help="Set the secret access key used to get provider oAuth token",
     required=False,
 )
+@click.option(
+    'output_only', '--output_only', '-o',
+    default=False,
+    is_flag=True,
+    help="Display the translation only",
+    required=False,
+)
 @click.argument('text', nargs=-1, type=click.STRING, required=True)
-def main(from_lang, to_lang, provider, secret_access_key, text):
+def main(from_lang, to_lang, provider, secret_access_key, output_only, text):
     """
     Python command line tool to make on line translations
 
@@ -153,6 +160,10 @@ def main(from_lang, to_lang, provider, secret_access_key, text):
     translation = translator.translate(text)
     if sys.version_info.major == 2:
         translation = translation.encode(locale.getpreferredencoding())
+
+    if output_only:
+        click.echo(translation)
+        return translation
 
     click.echo('\nTranslation: {}'.format(translation))
     click.echo('-' * 25)

--- a/translate/main.py
+++ b/translate/main.py
@@ -56,24 +56,20 @@ def print_version(ctx, param, value):
     'from_lang', '-f',
     default=TRANSLATION_FROM_DEFAULT,
     prompt='Translate from',
-    help="Sets the default language of the text being translated. The default value is 'autodetect'"
 )
 @click.option(
     'to_lang', '-t',
     prompt='Translate to',
-    help='Sets the default language you want to translate.'
 )
 @click.option(
     'provider', '-p',
     default=DEFAULT_PROVIDER,
     prompt='Provider',
-    help="Set the default provider you want to use. The default value is '{}'".format(DEFAULT_PROVIDER)
 )
 @click.option(
     'secret_access_key', '-s',
     default="",
     prompt='Secret Access Key',
-    help="Set the secret access key used to get provider oAuth token",
     required=False
 )
 @click.pass_context
@@ -106,7 +102,7 @@ def config_file(ctx, from_lang, to_lang, provider, secret_access_key):
     expose_value=False,
     is_flag=True,
     is_eager=True,
-    help='Show the version and exit.'
+    help='Generated the config file using a Wizard and exit.'
 )
 @click.option(
     'from_lang', '--from', '-f',

--- a/translate/main.py
+++ b/translate/main.py
@@ -107,7 +107,7 @@ def config_file(ctx, from_lang, to_lang, provider, secret_access_key):
 @click.option(
     'from_lang', '--from', '-f',
     default=get_config_info('from_lang') or TRANSLATION_FROM_DEFAULT,
-    help="Sets the language of the text being translated. The default value is 'autodetect'"
+    help="Sets the language of the text being translated. The default value is 'autodetect'."
 )
 @click.option(
     'to_lang', '--to', '-t',
@@ -118,19 +118,19 @@ def config_file(ctx, from_lang, to_lang, provider, secret_access_key):
 @click.option(
     'provider', '--provider', '-p',
     default=get_config_info('provider') or DEFAULT_PROVIDER,
-    help="Set the provider you want to use. The default value is '{}'".format(DEFAULT_PROVIDER)
+    help="Set the provider you want to use. The default value is '{}'.".format(DEFAULT_PROVIDER)
 )
 @click.option(
     'secret_access_key', '--secret_access_key',
     default=get_config_info('secret_access_key'),
-    help="Set the secret access key used to get provider oAuth token",
+    help="Set the secret access key used to get provider oAuth token.",
     required=False,
 )
 @click.option(
     'output_only', '--output_only', '-o',
     default=False,
     is_flag=True,
-    help="Display the translation only",
+    help="Set to display the translation only.",
     required=False,
 )
 @click.argument('text', nargs=-1, type=click.STRING, required=True)

--- a/translate/main.py
+++ b/translate/main.py
@@ -154,6 +154,8 @@ def main(from_lang, to_lang, provider, secret_access_key, text):
     if sys.version_info.major == 2:
         translation = translation.encode(locale.getpreferredencoding())
 
-    click.echo(translation)
+    click.echo('\nTranslation: {}'.format(translation))
+    click.echo('-' * 25)
+    click.echo('Translated by: {}'.format(translator.provider.name))
 
     return translation

--- a/translate/providers/base.py
+++ b/translate/providers/base.py
@@ -7,6 +7,7 @@ from abc import ABCMeta, abstractmethod
 class BaseProvider:
     __metaclass__ = ABCMeta
 
+    name = ''
     base_url = ''
 
     def __init__(self, to_lang, from_lang='en', secret_access_key=None, **kwargs):

--- a/translate/providers/microsoft.py
+++ b/translate/providers/microsoft.py
@@ -54,6 +54,7 @@ class MicrosoftProvider(BaseProvider):
     Website: http://docs.microsofttranslator.com
     Documentation: http://docs.microsofttranslator.com/text-translate.html
     '''
+    name = 'Microsoft'
     base_url = 'http://api.microsofttranslator.com/v2/Http.svc/Translate'
 
     def _make_request(self, text):

--- a/translate/providers/mymemory_translated.py
+++ b/translate/providers/mymemory_translated.py
@@ -18,6 +18,7 @@ class MyMemoryProvider(BaseProvider):
     http://mymemory.translated.net/doc/usagelimits.php
                                                     Tips from: @Bachstelze
     '''
+    name = 'MyMemory'
     base_url = 'http://api.mymemory.translated.net/get'
 
     def __init__(self, **kwargs):


### PR DESCRIPTION
PR adding the following features:

- Use the config file to set the default provider and the secret access key to get the providers oAuth token
- Add a command to generate config file using a "Wizard".

Example:
 - translate-cli command generating the user config file
```shell
$ translate-cli --generate-config-file
Translate from [autodetect]: 
Translate to: zh
Provider [mymemory]: 
Secret Access Key []: 

$ cat ~/.python-translate.cfg 
[DEFAULT]
from_lang = autodetect
to_lang = zh
provider = mymemory
secret_access_key =
```

- Help command with new option
```shell
Usage: __main__.py [OPTIONS] TEXT...

  Python command line tool to make on line translations

  Example:
  
       $ translate-cli -t zh the book is on the table
       碗是在桌子上。

  Available languages:
  
       https://en.wikipedia.org/wiki/ISO_639-1
       Examples: (e.g. en, ja, ko, pt, zh, zh-TW, ...)

Options:
  --version                 Show the version and exit.
  --generate-config-file    Generated the config file using a Wizard and exit.
  -f, --from TEXT           Sets the language of the text being translated.
                            The default value is 'autodetect'.
  -t, --to TEXT             Sets the language you want to translate.
  -p, --provider TEXT       Set the provider you want to use. The default
                            value is 'mymemory'.
  --secret_access_key TEXT  Set the secret access key used to get provider
                            oAuth token.
  -o, --output_only         Set to display the translation only.
  --help                    Show this message and exit.
```
PS: I fix the README content to get a better layout in PyPi website

This PR belongs to #38 issue
